### PR TITLE
New configuration parameter to specify a superuser

### DIFF
--- a/src/FSAL/access_check.c
+++ b/src/FSAL/access_check.c
@@ -831,6 +831,16 @@ fsal_status_t fsal_test_access(struct fsal_obj_handle *obj_hdl,
 	}
 }
 
+fsal_status_t fsal_super_user(struct fsal_obj_handle *obj_hdl,
+					uid_t uid, gid_t gid, bool *superuser)
+{
+	if (uid == 0)
+		*superuser = true;
+	else
+		*superuser = false;
+	return fsalstat(ERR_FSAL_NO_ERROR, 0);
+}
+
 uid_t ganesha_uid;
 gid_t ganesha_gid;
 int ganesha_ngroups;

--- a/src/FSAL/default_methods.c
+++ b/src/FSAL/default_methods.c
@@ -1061,6 +1061,7 @@ struct fsal_obj_ops def_handle_ops = {
 	.symlink = makesymlink,
 	.readlink = readsymlink,
 	.test_access = fsal_test_access,	/* default is use common test */
+	.super_user = fsal_super_user,
 	.getattrs = getattrs,
 	.setattrs = setattrs,
 	.link = linkfile,

--- a/src/cache_inode/cache_inode_access.c
+++ b/src/cache_inode/cache_inode_access.c
@@ -225,11 +225,19 @@ cache_inode_check_setattr_perms(cache_entry_t *entry,
 
 	/* Shortcut, if current user is root, then we can just bail out with
 	 * success. */
-	if (creds->caller_uid == 0) {
-		note = " (Ok for root user)";
+	struct fsal_obj_handle *pfsal_handle = entry->obj_handle;
+
+	bool superuser = false;
+	fsal_status_t ret =
+		pfsal_handle->obj_ops.super_user(
+					pfsal_handle,
+					creds->caller_uid,
+					creds->caller_gid,
+					&superuser);
+	if (!FSAL_IS_ERROR(ret) && superuser) {
+		note = " (Ok for superuser)";
 		goto out;
 	}
-
 	not_owner = (creds->caller_uid != entry->obj_handle->attrs->owner);
 
 	/* Only ownership change need to be checked for owner */

--- a/src/include/FSAL/access_check.h
+++ b/src/include/FSAL/access_check.h
@@ -17,6 +17,9 @@ fsal_status_t fsal_test_access(struct fsal_obj_handle *obj_hdl,
 			       fsal_accessflags_t *allowed,
 			       fsal_accessflags_t *denied);
 
+fsal_status_t fsal_super_user(struct fsal_obj_handle *obj_hdl,
+				uid_t uid, gid_t gid, bool *superuser);
+
 int display_fsal_v4mask(struct display_buffer *dspbuf, fsal_aceperm_t v4mask,
 			bool is_dir);
 

--- a/src/include/export_mgr.h
+++ b/src/include/export_mgr.h
@@ -127,6 +127,9 @@ struct gsh_export {
 
 	uint8_t export_status;		/*< current condition */
 	bool has_pnfs_ds;		/*< id_servers matches export_id */
+
+	/** Superuser uid */
+	uid_t superuser_uid;
 };
 
 void export_pkginit(void);

--- a/src/include/fsal_api.h
+++ b/src/include/fsal_api.h
@@ -1308,6 +1308,24 @@ struct fsal_obj_ops {
 				      fsal_accessflags_t *denied);
 
 /**
+ * @brief Check if the given uid is a superuser or not
+ *
+ * This function checks whether a given user is the
+ * superuser on the filesystem or not.
+ *
+ * @param[in] obj_hdl     Handle to check
+ * @param[in] uid         uid of the user to be checked
+ * @param[in] gid         gid of the user to be checked
+ * @param[out] superuser  true if the uid is of superuser,
+ *                        else false
+ *
+ * @return FSAL status.
+ */
+	 fsal_status_t (*super_user)(struct fsal_obj_handle *obj_hdl,
+						uid_t uid, gid_t gid,
+						bool *superuser);
+
+/**
  * @brief Get attributes
  *
  * This function freshens the cached attributes stored on the handle.

--- a/src/support/exports.c
+++ b/src/support/exports.c
@@ -1244,6 +1244,8 @@ static struct config_item export_params[] = {
 	CONF_ITEM_I32_SET("Attr_Expiration_Time", -1, INT32_MAX, 60,
 		       gsh_export, expire_time_attr,
 		       EXPORT_OPTION_EXPIRE_SET,  options_set),
+	CONF_ITEM_UI32("SuperUser_Uid", 0, UINT32_MAX, 0, gsh_export,
+		superuser_uid),
 
 	/* NOTE: the Client and FSAL sub-blocks must be the *last*
 	 * two entries in the list.  This is so all other


### PR DESCRIPTION
Some filesystems have another superuser who is not root.
One superuser can be added per export block.
Configuration parameter : SuperUser_Uid.
Value : uid of the superuser.

Change-Id: Ie25b59b218b85b96b66fd5cbd413b4a9fb362761
Signed-off-by: Satya G S <g.satyaprakash@gmail.com>