### PR TITLE
Logging too slow when full debug is enabled

### DIFF
--- a/src/MainNFSD/nfs_main.c
+++ b/src/MainNFSD/nfs_main.c
@@ -358,6 +358,7 @@ int main(int argc, char *argv[])
 	signal(SIGXFSZ, SIG_IGN);
 #endif
 
+	spawn_log_flusher();
 	/* Echo PID into pidfile */
 	pidfile = open(pidfile_path, O_CREAT | O_RDWR, 0644);
 	if (pidfile == -1) {

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -134,6 +134,8 @@ void SetClientIP(char *ip_str);
 
 void init_logging(const char *log_path, const int debug_level);
 
+int spawn_log_flusher(void);
+
 int ReturnLevelAscii(const char *LevelInAscii);
 char *ReturnLevelInt(int level);
 


### PR DESCRIPTION
Introduced a pool of files for logging. Every
thread will pick a file and log to it (sticks
to this file throughout). Threads log to a
buffer and leave. The buffer is periodically
flushed by the flusher thread or by the current
thread if the log is full. Significant response time
improvement seen in case of mount, ls -l, touch
of many files, etc.

Change-Id: Iefa8b8d48d2b29c68e9df6347a81eef932efe39f
Signed-off-by: Satya G S <g.satyaprakash@gmail.com>