### PR TITLE
Changing create to make it POSIX compatible when the file already exists

### DIFF
--- a/src/cache_inode/cache_inode_create.c
+++ b/src/cache_inode/cache_inode_create.c
@@ -216,6 +216,9 @@ cache_inode_create(cache_entry_t *parent,
 	/* Add this entry to the directory (also takes an internal ref) */
 	status = cache_inode_add_cached_dirent(parent, name, *entry, NULL);
 	PTHREAD_RWLOCK_unlock(&parent->content_lock);
+	if (status == CACHE_INODE_ENTRY_EXISTS)
+		status = CACHE_INODE_SUCCESS;
+
 	if (status != CACHE_INODE_SUCCESS) {
 		cache_inode_put(*entry);
 		*entry = NULL;


### PR DESCRIPTION
Ignoring the CACHE_INODE_ENTRY_EXISTS error when adding the new entry in
dir entry cache.

Change-Id: I06ebf84b74bbdb39e3aec1bc31b194f1e1edbcc9
Signed-off-by: Sriram Patil <spsrirampatil@gmail.com>