### PR TITLE
Flushing all the log buffers when shutting down

### DIFF
--- a/src/MainNFSD/nfs_admin_thread.c
+++ b/src/MainNFSD/nfs_admin_thread.c
@@ -464,6 +464,7 @@ static void do_shutdown(void)
 		LogEvent(COMPONENT_MAIN, "FSAL system destroyed.");
 	}
 
+	flush_all_logs(true /*close_fds*/);
 	unlink(pidfile_path);
 }
 

--- a/src/MainNFSD/nfs_main.c
+++ b/src/MainNFSD/nfs_main.c
@@ -489,6 +489,7 @@ fatal_die:
 	report_config_errors(&err_type, NULL, config_errs_to_log);
 	LogFatal(COMPONENT_INIT,
 		 "Fatal errors.  Server exiting...");
+	flush_all_logs(true /*close_fd*/);
 	/* NOT REACHED */
 	return 2;
 }

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -194,6 +194,7 @@ int disable_log_facility(char *name);
 int set_log_destination(char *name, char *dest);
 int set_log_level(char *name, log_levels_t max_level);
 void set_const_log_str(void);
+void flush_all_logs(bool close_fd);
 
 struct log_component_info {
 	const char *comp_name;	/* component name */


### PR DESCRIPTION
All the log buffers should be flushed when shutdown signal is received form
dbus. This ensures that all logs are written after graceful shutdown.

Change-Id: Ia971ac0ff42151e0f3e46486c000c7182ce9602d
Signed-off-by: Sriram Patil <spsrirampatil@gmail.com>