### PR TITLE
Fix file handle bytes switching in xdr_nfs_fh4 XDR_ENCODE

### DIFF
--- a/src/Protocols/NFS/nfs4_op_putfh.c
+++ b/src/Protocols/NFS/nfs4_op_putfh.c
@@ -91,7 +91,7 @@ int nfs4_op_putfh(struct nfs_argop4 *op, compound_data_t *data,
 	v4_handle = (struct file_handle_v4 *)data->currentFH.nfs_fh4_val;
 
 	LogFullDebug(COMPONENT_FILEHANDLE, "NFS4 Handle 0x%X export id %d",
-		v4_handle->fhflags1, v4_handle->id.exports);
+		v4_handle->fhflags1, ntohs(v4_handle->id.exports));
 
 	/* Copy the filehandle from the arg structure */
 	data->currentFH.nfs_fh4_len = arg_PUTFH4->object.nfs_fh4_len;
@@ -111,14 +111,14 @@ int nfs4_op_putfh(struct nfs_argop4 *op, compound_data_t *data,
 		/* Find any existing server by the "id" from the handle,
 		 * before releasing the old DS (to prevent thrashing).
 		 */
-		pds = pnfs_ds_get(v4_handle->id.servers);
+		pds = pnfs_ds_get(ntohs(v4_handle->id.servers));
 		if (pds == NULL) {
 			LogInfoAlt(COMPONENT_DISPATCH, COMPONENT_EXPORT,
 				"NFS4 Request from client (%s) has invalid server identifier %d",
 				op_ctx->client
 					? op_ctx->client->hostaddr_str
 					: "unknown",
-				v4_handle->id.servers);
+				ntohs(v4_handle->id.servers));
 
 			res_PUTFH4->status = NFS4ERR_STALE;
 			return res_PUTFH4->status;
@@ -126,7 +126,7 @@ int nfs4_op_putfh(struct nfs_argop4 *op, compound_data_t *data,
 
 		/* If old CurrentFH had a related server, release reference. */
 		if (op_ctx->fsal_pnfs_ds != NULL) {
-			changed = v4_handle->id.servers
+			changed = ntohs(v4_handle->id.servers)
 				!= op_ctx->fsal_pnfs_ds->id_servers;
 			pnfs_ds_put(op_ctx->fsal_pnfs_ds);
 		}
@@ -193,14 +193,14 @@ int nfs4_op_putfh(struct nfs_argop4 *op, compound_data_t *data,
 		/* Find any existing export by the "id" from the handle,
 		 * before releasing the old export (to prevent thrashing).
 		 */
-		exporting = get_gsh_export(v4_handle->id.exports);
+		exporting = get_gsh_export(ntohs(v4_handle->id.exports));
 		if (exporting == NULL) {
 			LogInfoAlt(COMPONENT_DISPATCH, COMPONENT_EXPORT,
 				"NFS4 Request from client (%s) has invalid export identifier %d",
 				op_ctx->client
 					? op_ctx->client->hostaddr_str
 					: "unknown",
-				v4_handle->id.exports);
+				ntohs(v4_handle->id.exports));
 
 			res_PUTFH4->status = NFS4ERR_STALE;
 			return res_PUTFH4->status;
@@ -208,7 +208,7 @@ int nfs4_op_putfh(struct nfs_argop4 *op, compound_data_t *data,
 
 		/* If old CurrentFH had a related export, release reference. */
 		if (op_ctx->export != NULL) {
-			changed = v4_handle->id.exports
+			changed = ntohs(v4_handle->id.exports)
 				!= op_ctx->export->export_id;
 			put_gsh_export(op_ctx->export);
 		}

--- a/src/Protocols/NFS/nfs_proto_tools.c
+++ b/src/Protocols/NFS/nfs_proto_tools.c
@@ -994,15 +994,9 @@ static fattr_xdr_result decode_chown_restricted(XDR *xdr,
 static fattr_xdr_result encode_filehandle(XDR *xdr,
 					  struct xdr_attrs_args *args)
 {
-	file_handle_v4_t *fh;
 
 	if (args->hdl4 == NULL || args->hdl4->nfs_fh4_val == NULL)
 		return FATTR_XDR_FAILED;
-
-	if (args->hdl4->nfs_fh4_len >= offsetof(file_handle_v4_t, fsopaque)) {
-		fh = (file_handle_v4_t *)args->hdl4->nfs_fh4_val;
-		fh->id.exports = htons(fh->id.exports);
-	}
 
 	if (!inline_xdr_bytes
 	    (xdr, &args->hdl4->nfs_fh4_val, &args->hdl4->nfs_fh4_len,
@@ -1016,7 +1010,6 @@ static fattr_xdr_result encode_filehandle(XDR *xdr,
 static fattr_xdr_result decode_filehandle(XDR *xdr,
 					  struct xdr_attrs_args *args)
 {
-	file_handle_v4_t *fh;
 	uint32_t fhlen = 0, pos;
 
 	if (args->hdl4 == NULL || args->hdl4->nfs_fh4_val == NULL) {
@@ -1030,11 +1023,6 @@ static fattr_xdr_result decode_filehandle(XDR *xdr,
 		    (xdr, &args->hdl4->nfs_fh4_val, &args->hdl4->nfs_fh4_len,
 		     NFS4_FHSIZE))
 			return FATTR_XDR_FAILED;
-		if (args->hdl4->nfs_fh4_len
-		    >= offsetof(file_handle_v4_t, fsopaque)) {
-			fh = (file_handle_v4_t *)args->hdl4->nfs_fh4_val;
-			fh->id.exports = ntohs(fh->id.exports);
-		}
 	}
 
 	return FATTR_XDR_SUCCESS;

--- a/src/Protocols/XDR/xdr_mount.c
+++ b/src/Protocols/XDR/xdr_mount.c
@@ -35,21 +35,11 @@ fhandle3 *objp;
 #else
 	register long __attribute__ ((__unused__)) * buf;
 #endif
-	if (xdrs->x_op == XDR_ENCODE &&
-	    objp->fhandle3_len >= offsetof(file_handle_v3_t, fsopaque)) {
-		file_handle_v3_t *fh = (file_handle_v3_t *)objp->fhandle3_val;
-		fh->exportid = htons(fh->exportid);
-	}
 	if (!inline_xdr_bytes
 	    (xdrs, (char **)&objp->fhandle3_val, (u_int *) & objp->fhandle3_len,
 	     NFS3_FHSIZE))
 		return (false);
 
-	if (xdrs->x_op == XDR_DECODE &&
-	    objp->fhandle3_len >= offsetof(file_handle_v3_t, fsopaque)) {
-		file_handle_v3_t *fh = (file_handle_v3_t *)objp->fhandle3_val;
-		fh->exportid = ntohs(fh->exportid);
-	}
 	return (true);
 }
 

--- a/src/Protocols/XDR/xdr_nfs23.c
+++ b/src/Protocols/XDR/xdr_nfs23.c
@@ -443,7 +443,6 @@ bool xdr_nfs_fh3(xdrs, objp)
 register XDR *xdrs;
 nfs_fh3 *objp;
 {
-	file_handle_v3_t *fh;
 
 #if defined(_LP64) || defined(_KERNEL)
 	register int __attribute__ ((__unused__)) * buf;
@@ -451,21 +450,11 @@ nfs_fh3 *objp;
 	register long __attribute__ ((__unused__)) * buf;
 #endif
 
-	if (xdrs->x_op == XDR_ENCODE &&
-	    objp->data.data_len >= offsetof(file_handle_v3_t, fsopaque)) {
-		fh = (file_handle_v3_t *)objp->data.data_val;
-		fh->exportid = htons(fh->exportid);
-	}
 	if (!xdr_bytes
 	    (xdrs, (char **)&objp->data.data_val,
 	     (u_int *) & objp->data.data_len, 64))
 		return (false);
 
-	if (xdrs->x_op == XDR_DECODE &&
-	    objp->data.data_len >= offsetof(file_handle_v3_t, fsopaque)) {
-		fh = (file_handle_v3_t *)objp->data.data_val;
-		fh->exportid = ntohs(fh->exportid);
-	}
 	return (true);
 }
 

--- a/src/Protocols/XDR/xdr_nlm4.c
+++ b/src/Protocols/XDR/xdr_nlm4.c
@@ -8,24 +8,6 @@
 #include "nlm4.h"
 #include "nfs_fh.h"
 
-void xdr_handle_decode(XDR * xdrs, netobj * obj)
-{
-	if (obj->n_len >= offsetof(file_handle_v3_t, fsopaque)) {
-		file_handle_v3_t *fh = (file_handle_v3_t *)obj->n_bytes;
-
-		fh->exportid = ntohs(fh->exportid);
-	}
-}
-
-void xdr_handle_encode(XDR * xdrs, netobj * obj)
-{
-	if (obj->n_len >= offsetof(file_handle_v3_t, fsopaque)) {
-		file_handle_v3_t *fh = (file_handle_v3_t *)obj->n_bytes;
-
-		fh->exportid = htons(fh->exportid);
-	}
-}
-
 bool xdr_nlm4_stats(XDR * xdrs, nlm4_stats * objp)
 {
 	if (!xdr_enum(xdrs, (enum_t *) objp))
@@ -92,12 +74,8 @@ bool xdr_nlm4_lock(XDR * xdrs, nlm4_lock * objp)
 {
 	if (!xdr_string(xdrs, &objp->caller_name, LM_MAXSTRLEN))
 		return false;
-	if (xdrs->x_op == XDR_ENCODE)
-		xdr_handle_encode(xdrs, &objp->fh);
 	if (!xdr_netobj(xdrs, &objp->fh))
 		return false;
-	if (xdrs->x_op == XDR_DECODE)
-		xdr_handle_decode(xdrs, &objp->fh);
 	if (!xdr_netobj(xdrs, &objp->oh))
 		return false;
 	if (!xdr_int32_t(xdrs, &objp->svid))
@@ -177,12 +155,8 @@ bool xdr_nlm4_share(XDR * xdrs, nlm4_share * objp)
 {
 	if (!xdr_string(xdrs, &objp->caller_name, LM_MAXSTRLEN))
 		return false;
-	if (xdrs->x_op == XDR_ENCODE)
-		xdr_handle_encode(xdrs, &objp->fh);
 	if (!xdr_netobj(xdrs, &objp->fh))
 		return false;
-	if (xdrs->x_op == XDR_DECODE)
-		xdr_handle_decode(xdrs, &objp->fh);
 	if (!xdr_netobj(xdrs, &objp->oh))
 		return false;
 	if (!xdr_fsh4_mode(xdrs, &objp->mode))

--- a/src/include/nfs_file_handle.h
+++ b/src/include/nfs_file_handle.h
@@ -114,7 +114,8 @@ static inline short nfs3_FhandleToExportId(nfs_fh3 *pfh3)
 
 	pfile_handle = (file_handle_v3_t *) (pfh3->data.data_val);
 
-	return pfile_handle->exportid;
+	/*exportid is in network byte order in nfs_fh3*/
+	return ntohs(pfile_handle->exportid);
 }				/* nfs3_FhandleToExportId */
 
 static inline short nlm4_FhandleToExportId(netobj *pfh3)

--- a/src/include/nfsv41.h
+++ b/src/include/nfsv41.h
@@ -3699,23 +3699,10 @@ extern "C" {
 
 	static inline bool xdr_nfs_fh4(XDR * xdrs, nfs_fh4 *objp)
 	{
-		file_handle_v4_t *fh;
-
-		if (xdrs->x_op == XDR_ENCODE &&
-		    objp->nfs_fh4_len >= offsetof(file_handle_v4_t, fsopaque)) {
-			fh = (file_handle_v4_t *)objp->nfs_fh4_val;
-			fh->id.exports = htons(fh->id.exports);
-		}
 		if (!inline_xdr_bytes
-		    (xdrs, (char **)&objp->nfs_fh4_val,
+		    (xdrs, (char **) &objp->nfs_fh4_val,
 		     &objp->nfs_fh4_len, NFS4_FHSIZE))
 			return false;
-
-		if (xdrs->x_op == XDR_DECODE &&
-		    objp->nfs_fh4_len >= offsetof(file_handle_v4_t, fsopaque)) {
-			fh = (file_handle_v4_t *)objp->nfs_fh4_val;
-			fh->id.exports = ntohs(fh->id.exports);
-		}
 		return true;
 	}
 

--- a/src/support/nfs_filehandle_mgmt.c
+++ b/src/support/nfs_filehandle_mgmt.c
@@ -142,7 +142,7 @@ cache_entry_t *nfs3_FhandleToCache(nfs_fh3 *fh3,
 	/* Cast the fh as a non opaque structure */
 	v3_handle = (file_handle_v3_t *) (fh3->data.data_val);
 
-	assert(v3_handle->exportid == op_ctx->export->export_id);
+	assert(ntohs(v3_handle->exportid) == op_ctx->export->export_id);
 
 	export = op_ctx->fsal_export;
 
@@ -210,14 +210,14 @@ bool nfs4_FSALToFhandle(nfs_fh4 *fh4,
 	file_handle->fhflags1 = FH_FSAL_BIG_ENDIAN;
 #endif
 	file_handle->fs_len = fh_desc.len;	/* set the actual size */
-	/* keep track of the export id */
-	file_handle->id.exports = exp->export_id;
+	/* keep track of the export id network byte order for nfs_fh4*/
+	file_handle->id.exports = htons(exp->export_id);
 
 	/* Set the len */
 	fh4->nfs_fh4_len = nfs4_sizeof_handle(file_handle);
 
 	LogFullDebug(COMPONENT_FILEHANDLE, "NFS4 Handle 0x%X export id %d",
-		file_handle->fhflags1, file_handle->id.exports);
+		file_handle->fhflags1, ntohs(file_handle->id.exports));
 	LogFullDebugOpaque(COMPONENT_FILEHANDLE, "NFS4 Handle %s", LEN_FH_STR,
 			   fh4->nfs_fh4_val, fh4->nfs_fh4_len);
 
@@ -266,8 +266,8 @@ bool nfs3_FSALToFhandle(nfs_fh3 *fh3,
 	file_handle->fhflags1 = FH_FSAL_BIG_ENDIAN;
 #endif
 	file_handle->fs_len = fh_desc.len;	/* set the actual size */
-	/* keep track of the export id */
-	file_handle->exportid = exp->export_id;
+	/* keep track of the export id in network byte order*/
+	file_handle->exportid = htons(exp->export_id);
 
 	/* Set the len */
 	/* re-adjust to as built */
@@ -332,7 +332,7 @@ int nfs4_Is_Fh_Invalid(nfs_fh4 *fh)
 	pfile_handle = (file_handle_v4_t *) (fh->nfs_fh4_val);
 
 	LogFullDebug(COMPONENT_FILEHANDLE, "NFS4 Handle 0x%X export id %d",
-		pfile_handle->fhflags1, pfile_handle->id.exports);
+		pfile_handle->fhflags1, ntohs(pfile_handle->id.exports));
 
 	/* validate the filehandle  */
 	if (pfile_handle == NULL || fh->nfs_fh4_len == 0
@@ -374,7 +374,7 @@ int nfs4_Is_Fh_Invalid(nfs_fh4 *fh)
 			} else {
 				LogInfo(COMPONENT_FILEHANDLE,
 					"INVALID HANDLE: is_pseudofs=%d",
-					pfile_handle->id.exports == 0);
+					ntohs(pfile_handle->id.exports) == 0);
 			}
 		}
 


### PR DESCRIPTION
FSAL_PROXY tests reveals a "Stale file handle" error at
first ls on root directory. This was due to call to htons
in the encode way that was switching bytes and corrupting
the file handle in FSAL_PROXY. To fix this issue, we simply
choose to let export id in network byte order in the handle
and only revert it when we extract it. This commit fix NFSv3
and NFSv4 protocols.

Change-Id: Ia682d0ce83d19ee873c1c7a993e6c86499c48bd7
Signed-off-by: Patrice LUCAS <patrice.lucas@cea.fr>