### PR TITLE
Bug 30967 - ls from nfs4 mount path from is slow even for 10k files f…

### DIFF
--- a/src/FSAL/FSAL_GLUSTER/handle.c
+++ b/src/FSAL/FSAL_GLUSTER/handle.c
@@ -153,7 +153,8 @@ static fsal_status_t lookup(struct fsal_obj_handle *parent,
 
 static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 				  fsal_cookie_t *whence, void *dir_state,
-				  fsal_readdir_cb cb, bool *eof)
+				  fsal_readdir_cb cb, bool *eof,
+				  int64_t num_entries)
 {
 	int rc = 0;
 	fsal_status_t status = { ERR_FSAL_NO_ERROR, 0 };

--- a/src/FSAL/FSAL_GPFS/handle.c
+++ b/src/FSAL/FSAL_GPFS/handle.c
@@ -442,7 +442,8 @@ static fsal_status_t linkfile(struct fsal_obj_handle *obj_hdl,
 
 static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 				  fsal_cookie_t *whence, void *dir_state,
-				  fsal_readdir_cb cb, bool *eof)
+				  fsal_readdir_cb cb, bool *eof,
+				  uint64_t num_entries)
 {
 	fsal_errors_t fsal_error = ERR_FSAL_NO_ERROR;
 	int retval = 0;
@@ -490,7 +491,7 @@ static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 
 			/* callback to cache inode */
 			if (!cb(dentry->d_name, dir_state,
-				(fsal_cookie_t) dentry->d_off)) {
+				(fsal_cookie_t) dentry->d_off, NULL)) {
 				goto done;
 			}
  skip:

--- a/src/FSAL/FSAL_PROXY/handle.c
+++ b/src/FSAL/FSAL_PROXY/handle.c
@@ -1592,7 +1592,7 @@ static fsal_status_t pxy_do_readdir(struct pxy_obj_handle *ph,
 
 		*cookie = e4->cookie;
 
-		if (!cb(name, cbarg, e4->cookie))
+		if (!cb(name, cbarg, e4->cookie, NULL))
 			break;
 	}
 	xdr_free((xdrproc_t) xdr_readdirres, resoparray);
@@ -1602,7 +1602,8 @@ static fsal_status_t pxy_do_readdir(struct pxy_obj_handle *ph,
 /* What to do about verifier if server needs one? */
 static fsal_status_t pxy_readdir(struct fsal_obj_handle *dir_hdl,
 				 fsal_cookie_t *whence, void *cbarg,
-				 fsal_readdir_cb cb, bool *eof)
+				 fsal_readdir_cb cb, bool *eof,
+				 uint64_t num_entries)
 {
 	nfs_cookie4 cookie = 0;
 	struct pxy_obj_handle *ph;

--- a/src/FSAL/FSAL_PSEUDO/handle.c
+++ b/src/FSAL/FSAL_PSEUDO/handle.c
@@ -495,7 +495,8 @@ static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 				  fsal_cookie_t *whence,
 				  void *dir_state,
 				  fsal_readdir_cb cb,
-				  bool *eof)
+				  bool *eof,
+				  uint64_t num_entries)
 {
 	struct pseudo_fsal_obj_handle *myself, *hdl;
 	struct avltree_node *node;
@@ -533,7 +534,7 @@ static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 		if (hdl->index < seekloc)
 			continue;
 
-		if (!cb(hdl->name, dir_state, hdl->index)) {
+		if (!cb(hdl->name, dir_state, hdl->index, NULL)) {
 			*eof = false;
 			break;
 		}

--- a/src/FSAL/FSAL_PT/handle.c
+++ b/src/FSAL/FSAL_PT/handle.c
@@ -376,7 +376,8 @@ struct linux_dirent {
  */
 static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 				  uint64_t *whence, void *dir_state,
-				  fsal_readdir_cb cb, bool *eof)
+				  fsal_readdir_cb cb, bool *eof,
+				  int64_t num_entries);
 {
 	struct pt_fsal_obj_handle *myself;
 	int dirfd;

--- a/src/FSAL/FSAL_VFS/handle.c
+++ b/src/FSAL/FSAL_VFS/handle.c
@@ -1009,7 +1009,8 @@ static fsal_status_t linkfile(struct fsal_obj_handle *obj_hdl,
 
 static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 				  fsal_cookie_t *whence, void *dir_state,
-				  fsal_readdir_cb cb, bool *eof)
+				  fsal_readdir_cb cb, bool *eof,
+				  uint64_t num_entries)
 {
 	struct vfs_fsal_obj_handle *myself;
 	int dirfd;
@@ -1066,7 +1067,7 @@ static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 
 			/* callback to cache inode */
 			if (!cb(dentryp->vd_name, dir_state,
-				(fsal_cookie_t) dentryp->vd_offset)) {
+				(fsal_cookie_t) dentryp->vd_offset, NULL)) {
 				goto done;
 			}
  skip:

--- a/src/FSAL/Stackable_FSALs/FSAL_NULL/handle.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_NULL/handle.c
@@ -336,13 +336,14 @@ static fsal_status_t linkfile(struct fsal_obj_handle *obj_hdl,
  * @return Result coming from the upper layer.
  */
 static bool nullfs_readdir_cb(const char *name, void *dir_state,
-			       fsal_cookie_t cookie)
+					fsal_cookie_t cookie,
+					struct fsal_obj_handle *obj_hdl)
 {
 	struct nullfs_readdir_state *state =
 		(struct nullfs_readdir_state *) dir_state;
 
 	op_ctx->fsal_export = &state->exp->export;
-	bool result = state->cb(name, state->dir_state, cookie);
+	bool result = state->cb(name, state->dir_state, cookie, obj_hdl);
 
 	op_ctx->fsal_export = state->exp->sub_export;
 
@@ -362,7 +363,8 @@ static bool nullfs_readdir_cb(const char *name, void *dir_state,
 
 static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 				  fsal_cookie_t *whence, void *dir_state,
-				  fsal_readdir_cb cb, bool *eof)
+				  fsal_readdir_cb cb, bool *eof,
+				  uint64_t num_entries)
 {
 	struct nullfs_fsal_obj_handle *handle =
 		container_of(dir_hdl, struct nullfs_fsal_obj_handle,
@@ -382,7 +384,7 @@ static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 	op_ctx->fsal_export = export->sub_export;
 	fsal_status_t status =
 		handle->sub_handle->obj_ops.readdir(handle->sub_handle,
-		whence, &cb_state, nullfs_readdir_cb, eof);
+		whence, &cb_state, nullfs_readdir_cb, eof, 0);
 	op_ctx->fsal_export = &export->export;
 
 	return status;

--- a/src/FSAL/default_methods.c
+++ b/src/FSAL/default_methods.c
@@ -577,7 +577,8 @@ static fsal_status_t lookup(struct fsal_obj_handle *parent,
 
 static fsal_status_t read_dirents(struct fsal_obj_handle *dir_hdl,
 				  fsal_cookie_t *whence, void *dir_state,
-				  fsal_readdir_cb cb, bool *eof)
+				  fsal_readdir_cb cb, bool *eof,
+				  uint64_t num_entries)
 {
 	return fsalstat(ERR_FSAL_NOTSUPP, 0);
 }

--- a/src/Protocols/9P/9p_readdir.c
+++ b/src/Protocols/9P/9p_readdir.c
@@ -284,7 +284,8 @@ int _9p_readdir(struct _9p_request_data *req9p, u32 *plenout, char *preply)
 	cache_status = cache_inode_readdir(pfid->pentry, cookie, &num_entries,
 					   &eod_met,
 					   0,	/* no attr */
-					   _9p_readdir_callback, &tracker);
+					   _9p_readdir_callback, &tracker,
+					   0);
 	if (cache_status != CACHE_INODE_SUCCESS) {
 		/* The avl lookup will try to get the next entry after 'cookie'.
 		 * If none is found CACHE_INODE_NOT_FOUND is returned

--- a/src/Protocols/NFS/nfs3_readdir.c
+++ b/src/Protocols/NFS/nfs3_readdir.c
@@ -295,7 +295,8 @@ int nfs3_readdir(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 					   &eod_met,
 					   0,	/* no attr */
 					   nfs3_readdir_callback,
-					   &tracker);
+					   &tracker,
+					   0);
 
 	if (cache_status != CACHE_INODE_SUCCESS) {
 		if (nfs_RetryableError(cache_status)) {

--- a/src/Protocols/NFS/nfs3_readdirplus.c
+++ b/src/Protocols/NFS/nfs3_readdirplus.c
@@ -295,7 +295,8 @@ int nfs3_readdirplus(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 					   &eod_met,
 					   ATTRS_NFS3,
 					   nfs3_readdirplus_callback,
-					   &tracker);
+					   &tracker,
+					   0);
 
 	if (cache_status != CACHE_INODE_SUCCESS) {
 		/* Is this a retryable error */

--- a/src/Protocols/NFS/nfs4_op_readdir.c
+++ b/src/Protocols/NFS/nfs4_op_readdir.c
@@ -521,7 +521,7 @@ int nfs4_op_readdir(struct nfs_argop4 *op, compound_data_t *data,
 	 * The Linux 3.0, 3.1.0 clients vs. TCP Ganesha comes out 10x slower
 	 * with 500 max entries
 	 */
-	estimated_num_entries = 50;
+	estimated_num_entries = 35;
 	tracker.total_entries = estimated_num_entries;
 
 	LogFullDebug(COMPONENT_NFS_READDIR,
@@ -617,7 +617,8 @@ int nfs4_op_readdir(struct nfs_argop4 *op, compound_data_t *data,
 					   &eod_met,
 					   attrmask,
 					   nfs4_readdir_callback,
-					   &tracker);
+					   &tracker,
+					   estimated_num_entries);
 
 	if (cache_status != CACHE_INODE_SUCCESS) {
 		res_READDIR4->status = nfs4_Errno(cache_status);

--- a/src/Protocols/NFS/nfs_proto_tools.c
+++ b/src/Protocols/NFS/nfs_proto_tools.c
@@ -3255,7 +3255,8 @@ nfsstat4 cache_entry_To_Fattr(cache_entry_t *entry, fattr4 *Fattr,
 	}
 
 	return nfs4_Errno(
-		cache_inode_getattr(entry, &f, Fattr_filler, CB_ORIGINAL));
+		cache_inode_getattr(entry, &f, Fattr_filler,
+					CB_ORIGINAL, false));
 }
 
 int nfs4_Fattr_Fill_Error(fattr4 *Fattr, nfsstat4 rdattr_error)

--- a/src/include/fsal_api.h
+++ b/src/include/fsal_api.h
@@ -1097,7 +1097,8 @@ static inline int sizeof_fsid(enum fsid_type type)
 typedef uint64_t fsal_cookie_t;
 
 typedef bool (*fsal_readdir_cb)(const char *name, void *dir_state,
-				fsal_cookie_t cookie);
+					fsal_cookie_t cookie,
+					struct fsal_obj_handle *obj_hdl);
 /**
  * @brief FSAL object operations vector
  */
@@ -1153,12 +1154,13 @@ struct fsal_obj_ops {
  * This function reads directory entries from the FSAL and supplies
  * them to a callback.
  *
- * @param[in]  dir_hdl   Directory to read
- * @param[in]  whence    Point at which to start reading.  NULL to
- *                       start at beginning.
- * @param[in]  dir_state Opaque pointer to be passed to callback
- * @param[in]  cb        Callback to receive names
- * @param[out] eof       true if the last entry was reached
+ * @param[in]  dir_hdl       Directory to read
+ * @param[in]  whence        Point at which to start reading.  NULL to
+ *                           start at beginning.
+ * @param[in]  dir_state     Opaque pointer to be passed to callback
+ * @param[in]  cb            Callback to receive names
+ * @param[out] eof           true if the last entry was reached
+ * @param[in]  num_entries   Directory entries to fetch in one RPC
  *
  * @retval true if more entries are required
  * @retval false if no more entries are required (and the current one
@@ -1168,7 +1170,8 @@ struct fsal_obj_ops {
 				  fsal_cookie_t *whence,
 				  void *dir_state,
 				  fsal_readdir_cb cb,
-				  bool *eof);
+				  bool *eof,
+				  uint64_t num_entries);
 /**@}*/
 
 /**@{*/

--- a/src/include/gsh_config.h
+++ b/src/include/gsh_config.h
@@ -404,6 +404,11 @@ typedef struct nfs_core_param {
  */
 #define DELEG_RECALL_RETRY_DELAY_DEFAULT 1
 
+/**
+ * @brief Default value of dirent_cache_threshold.
+ */
+#define DIRENT_CACHE_THRESHOLD_DEFAULT 128
+
 typedef struct nfs_version4_parameter {
 	/** Whether to disable the NFSv4 grace period.  Defaults to
 	    false and settable with Graceless. */
@@ -444,6 +449,8 @@ typedef struct nfs_version4_parameter {
 	bool pnfs_mds;
 	/** Whether this a pNFS DS server. Defaults to false */
 	bool pnfs_ds;
+	/** Threshold to decide if the dirent cache should be used. */
+	uint64_t dirent_cache_threshold;
 } nfs_version4_parameter_t;
 
 /** @} */

--- a/src/support/nfs_read_conf.c
+++ b/src/support/nfs_read_conf.c
@@ -249,6 +249,9 @@ static struct config_item version4_params[] = {
 		       nfs_version4_parameter, pnfs_mds),
 	CONF_ITEM_BOOL("PNFS_DS", true,
 		       nfs_version4_parameter, pnfs_ds),
+	CONF_ITEM_UI64("Dirent_Cache_Threshold", 0, UINT64_MAX,
+			DIRENT_CACHE_THRESHOLD_DEFAULT,
+			nfs_version4_parameter, dirent_cache_threshold),
 	CONFIG_EOL
 };
 


### PR DESCRIPTION
…rom user.

Problem description:
1. nfs ganesha does readdir and fetches all directory entries into dirent cache
2. It invalidates dirent cache every 3 seconds.
3. In one readdir operation client can consume a maximum of 50 entries at most.
4. If by the time client consumed these entries, 3 seconds are passes, the readdir in step (1) is re-attempted.
5. This means for 50 entries, nfs4, through mapr client endsup making 100s of readdir RPC, 1000s of lookup RPC, 1000s of getattr RPC.

All these were creating the slow down.

So, the fix targets reducing the number of RPC by following steps

1. Allow nfs4 server to issue a readdirplus request
2. Get the fsal_obj_handle through the readdir callback and avoid lookups
3. Specify the cookie and num_entries that nfs4 server can server to minimize readdir overhead
4. Skip direnct cache and exit readdirplus as soon as num_entries are populated.
5. Make sure for large directories other operations like create, remove, rename do not use dirent cache.
6. Also Made optimizations in the fsal layer to avoid getattrs calls.