### PR TITLE
Bug 31511 - nfs4 ganesha core at /mapr-nfsganesha-2.3.0/src/cache_ino…

### DIFF
--- a/src/cache_inode/cache_inode_getattr.c
+++ b/src/cache_inode/cache_inode_getattr.c
@@ -87,6 +87,8 @@ cache_inode_getattr(cache_entry_t *entry,
 				 cache_inode_err_str(status));
 			return status;
 		}
+	} else {
+		PTHREAD_RWLOCK_rdlock(&entry->attr_lock);
 	}
 
 	PTHREAD_RWLOCK_rdlock(&op_ctx->export->lock);


### PR DESCRIPTION
…de/cache_inode_misc.c:878

attr_lock gets unlocked without locking when trust_attrs is true.
This causes incorrect locking behavior and so the core.

Fix it by taking rdlock on attr_lock when trust_attrs is true.

skipBuild
unitTested

Change-Id: Iebf9e1731a17fde38d8e59bf7c8b6d1f852808f8
Signed-off-by: Krishna Kankanala <kkankanala@maprtech.com>