### PR TITLE
Bug 30995 - Provide configuration parameter to limit ganesha log file…

### DIFF
--- a/src/MainNFSD/nfs_init.c
+++ b/src/MainNFSD/nfs_init.c
@@ -202,6 +202,8 @@ void nfs_print_param_config(void)
 	       (uint64_t) nfs_param.core_param.decoder_fridge_block_timeout);
         printf("\tNumber of log files = %d\n",
                nfs_param.core_param.num_log_files);
+        printf("\tMaximum size of log files = %u\n",
+               nfs_param.core_param.max_logfile_size);
         printf("\tDirent entries track = %d\n",
                nfs_param.core_param.dirent_entries_track);
 	printf("\tManage_Gids_Expiration = %" PRIu64 " ;\n",

--- a/src/MainNFSD/nfs_main.c
+++ b/src/MainNFSD/nfs_main.c
@@ -130,6 +130,7 @@ int main(int argc, char *argv[])
 	sigset_t signals_to_block;
 	struct config_error_type err_type;
         nfs_param.core_param.num_log_files = 1;
+        nfs_param.core_param.max_logfile_size = MAX_LOGFILE_SIZE;
 	/* Set the server's boot time and epoch */
 	now(&ServerBootTime);
 	ServerEpoch = (time_t) ServerBootTime.tv_sec;

--- a/src/include/gsh_config.h
+++ b/src/include/gsh_config.h
@@ -163,6 +163,11 @@ typedef enum protos {
 #define NUM_LOG_FILES 32
 
 /**
+ * Default value for core_param.max_logfile_size
+ */
+#define MAX_LOGFILE_SIZE (1024 * 1024 * 1024)
+
+/**
  * @brief Support NFSv3
  */
 
@@ -369,6 +374,8 @@ typedef struct nfs_core_param {
 	bool dirent_entries_track;
 	/* Number of log files */
 	uint32_t num_log_files;
+	/* Max log file size */
+	uint32_t max_logfile_size;
 } nfs_core_parameter_t;
 
 /** @} */

--- a/src/support/nfs_read_conf.c
+++ b/src/support/nfs_read_conf.c
@@ -172,6 +172,8 @@ static struct config_item core_params[] = {
                        nfs_core_param, dirent_entries_track),
 	CONF_ITEM_UI32("Num_Log_Files", 1, NUM_LOG_FILES, NUM_LOG_FILES,
                        nfs_core_param, num_log_files),
+	CONF_ITEM_UI32("Max_Logfile_Size", 256*1024, 1*1024*1024*1024 /*1GB*/,
+			MAX_LOGFILE_SIZE, nfs_core_param, max_logfile_size),
 	CONFIG_EOL
 };
 


### PR DESCRIPTION
…s and enable log rotation on nfs4server log file -unitTested -skipBuild

Log rotation for nfs4server files greater than 200MB.