### PR TITLE
Bug 32138 - ganesha core at /mapr-nfsganesha-2.3.0/src/support/export…

### DIFF
--- a/src/support/exports.c
+++ b/src/support/exports.c
@@ -574,7 +574,7 @@ static int fsal_commit(void *node, void *link_mem, void *self_struct,
 	 * with. But only if it's a non-root path starting
 	 * with /.
 	 */
-	if (export->fullpath[0] == '/') {
+	if (export->fullpath && export->fullpath[0] == '/') {
 		int pathlen;
 
 		pathlen = strlen(export->fullpath);


### PR DESCRIPTION
…s.c:577

Put null check for export full path
All entries are ignored if config file has config error.

Now only export id 0 and / is exported.

Below are the logs
16/08/2018 19:51:09 : epoch 5b758855 : atsqa4-130 : ganesha.nfsd-16718[main] ganesha_yyerror :CONFIG :CRIT :Config file (/opt/mapr/conf/nfs4server.conf:108) error: syntax error
  3
...
...
16/08/2018 T19:51:09.161572+0530 16718[none] [main] 140 :fsal_create_export :Error while pathwalk of (null) err 22
 21 16/08/2018 T19:51:09.161597+0530 16718[none] [main] 2267 :fsal_put :FSAL MAPR now unused
 22 16/08/2018 T19:51:09.161605+0530 16718[none] [main] 609 :fsal_commit :Could not create export for ((null)) to ((null))
 23 16/08/2018 T19:51:09.161638+0530 16718[none] [main] 713 :export_commit_common :Exporting to NFSv4 but not Pseudo path defined
 24 16/08/2018 T19:51:09.161727+0530 16718[none] [main] 1443 :build_default_root :Export 0 (/) successfully created
 25 16/08/2018 T19:51:09.161735+0530 16718[none] [main] 477 :main :No export entries found in configuration file !!!