### PR TITLE
Bug 31960 - Post write getattr is degrading nfs4 server performance

### DIFF
--- a/src/cache_inode/cache_inode_misc.c
+++ b/src/cache_inode/cache_inode_misc.c
@@ -292,6 +292,7 @@ cache_inode_new_entry(struct fsal_obj_handle *new_obj,
 	nentry->type = new_obj->type;
 	nentry->flags = 0;
 	nentry->icreate_refcnt = 0;
+	nentry->size_changeid = 0;
 	glist_init(&nentry->list_of_states);
 	glist_init(&nentry->export_list);
 	glist_init(&nentry->layoutrecall_list);

--- a/src/cache_inode/cache_inode_rdwr.c
+++ b/src/cache_inode/cache_inode_rdwr.c
@@ -96,6 +96,8 @@ cache_inode_status_t cache_inode_rdwr(cache_entry_t *entry,
 	bool attributes_locked = false;
 	/* TRUE if we opened a previously closed FD */
 	bool opened = false;
+	struct post_attr_size attrsize;
+	uint64_t before = 0;
 
 	cache_inode_status_t status = CACHE_INODE_SUCCESS;
 
@@ -169,25 +171,42 @@ cache_inode_status_t cache_inode_rdwr(cache_entry_t *entry,
 	} else {
 		bool fsal_sync = *sync;
 
-		if (io_direction == CACHE_INODE_WRITE)
+		attrsize.file_size = 0;
+		attrsize.is_valid = false;
+
+		if (io_direction == CACHE_INODE_WRITE) {
+			if (nfs_param.nfsv4_param.post_write_attrs_update &&
+					(obj_hdl->obj_ops.write_post_attrs != NULL)) {
+				before = entry->size_changeid;
+				fsal_status =
+					obj_hdl->obj_ops.write_post_attrs(
+							obj_hdl, offset,
+							io_size, buffer,
+							bytes_moved,
+							&fsal_sync,
+							&attrsize);
+			} else {
+				fsal_status =
+					obj_hdl->obj_ops.write(obj_hdl,
+							offset, io_size,
+							buffer, bytes_moved,
+							&fsal_sync);
+			}
+		} else {
 			fsal_status =
-			  obj_hdl->obj_ops.write(obj_hdl, offset,
-					      io_size, buffer, bytes_moved,
-					      &fsal_sync);
-		else
-			fsal_status =
-			  obj_hdl->obj_ops.write_plus(obj_hdl, offset,
-						   io_size, buffer,
-						   bytes_moved, &fsal_sync,
-						   info);
+				obj_hdl->obj_ops.write_plus(obj_hdl, offset,
+						io_size, buffer,
+						bytes_moved, &fsal_sync,
+						info);
+		}
 		/* Alright, the unstable write is complete. Now if it was
 		   supposed to be a stable write we can sync to the hard
 		   drive. */
 
 		if (*sync && !(obj_hdl->obj_ops.status(obj_hdl) & FSAL_O_SYNC)
-		    && !fsal_sync && !FSAL_IS_ERROR(fsal_status)) {
+				&& !fsal_sync && !FSAL_IS_ERROR(fsal_status)) {
 			fsal_status = obj_hdl->obj_ops.commit(obj_hdl,
-							   offset, io_size);
+					offset, io_size);
 		} else {
 			*sync = fsal_sync;
 		}
@@ -269,12 +288,33 @@ cache_inode_status_t cache_inode_rdwr(cache_entry_t *entry,
 	PTHREAD_RWLOCK_wrlock(&entry->attr_lock);
 	attributes_locked = true;
 	if (io_direction == CACHE_INODE_WRITE ||
-	    io_direction == CACHE_INODE_WRITE_PLUS) {
-		status = cache_inode_refresh_attrs(entry);
+			io_direction == CACHE_INODE_WRITE_PLUS) {
+		bool needRefresh = true;
+		if (nfs_param.nfsv4_param.post_write_attrs_update) {
+			needRefresh = !cache_inode_is_attrs_valid(entry);
+			if (!needRefresh && (!attrsize.is_valid ||
+						(before != entry->size_changeid))) {
+				needRefresh = true;
+			}
+		}
+		LogDebug(COMPONENT_CACHE_INODE,
+				"cache_inode_rdwr: post_write_attrs_update=%d, Can refresh attributes=%d",
+				nfs_param.nfsv4_param.post_write_attrs_update,
+				needRefresh);
+		if (needRefresh) {
+			status = cache_inode_refresh_attrs(entry);
+		} else {
+			if (obj_hdl->attrs->filesize < attrsize.file_size)
+				obj_hdl->attrs->filesize = attrsize.file_size;
+			cache_inode_set_time_current(&obj_hdl->attrs->mtime);
+			status = CACHE_INODE_SUCCESS;
+		}
 		if (status != CACHE_INODE_SUCCESS)
 			goto out;
-	} else
+	} else {
 		cache_inode_set_time_current(&obj_hdl->attrs->atime);
+	}
+
 	PTHREAD_RWLOCK_unlock(&entry->attr_lock);
 	attributes_locked = false;
 

--- a/src/cache_inode/cache_inode_setattr.c
+++ b/src/cache_inode/cache_inode_setattr.c
@@ -201,7 +201,10 @@ cache_inode_setattr(cache_entry_t *entry,
 	/* Copy the complete set of new attributes out. */
 
 	*attr = *entry->obj_handle->attrs;
-
+	if (attr->mask & (ATTR_SIZE | ATTR4_SPACE_RESERVED)) {
+		/*protected by content_lock and attr_lock*/
+		entry->size_changeid++;
+	}
 	status = CACHE_INODE_SUCCESS;
 
 unlock:

--- a/src/include/cache_inode.h
+++ b/src/include/cache_inode.h
@@ -531,6 +531,11 @@ struct cache_entry_t {
 			struct glist_head export_roots;
 		} dir;		/*< DIRECTORY data */
 	} object;
+	/** size_changeid is used to check the local entry
+	setattr operation on size - typicall from truncate
+	operation on the entry - helps in rdwr()
+	protected by content and attr lock  */
+	uint64_t size_changeid;
 };
 
 /**

--- a/src/include/fsal_api.h
+++ b/src/include/fsal_api.h
@@ -359,6 +359,11 @@ struct io_hints {
 	uint32_t hints;
 };
 
+struct post_attr_size {
+	size_t file_size;
+	bool is_valid;
+};
+
 /**
  * @brief request op context
  *
@@ -1539,6 +1544,14 @@ struct fsal_obj_ops {
 				void *buffer,
 				size_t *wrote_amount,
 				bool *fsal_stable);
+
+	fsal_status_t (*write_post_attrs)(struct fsal_obj_handle *obj_hdl,
+				uint64_t offset,
+				size_t buffer_size,
+				void *buffer,
+				size_t *wrote_amount,
+				bool *fsal_stable,
+				struct post_attr_size *attrsize);
 /**
  * @brief Write data to a file plus
  *

--- a/src/include/gsh_config.h
+++ b/src/include/gsh_config.h
@@ -458,6 +458,9 @@ typedef struct nfs_version4_parameter {
 	bool pnfs_ds;
 	/** Threshold to decide if the dirent cache should be used. */
 	uint64_t dirent_cache_threshold;
+	/** Check for bypassing refresh of attributes if valid.
+	Defaults to true */
+	bool post_write_attrs_update;
 } nfs_version4_parameter_t;
 
 /** @} */

--- a/src/support/nfs_read_conf.c
+++ b/src/support/nfs_read_conf.c
@@ -254,6 +254,8 @@ static struct config_item version4_params[] = {
 	CONF_ITEM_UI64("Dirent_Cache_Threshold", 0, UINT64_MAX,
 			DIRENT_CACHE_THRESHOLD_DEFAULT,
 			nfs_version4_parameter, dirent_cache_threshold),
+	CONF_ITEM_BOOL("Post_Write_Attrs_Update", true,
+			nfs_version4_parameter, post_write_attrs_update),
 	CONFIG_EOL
 };
 


### PR DESCRIPTION
Fix Description:
Returning size as part of write call
Ignore the size of write call, if in case of truncate
happens from the same client - and get the attrs

Signed-off-by: chakragithub <chakragithub@gmail.com>