### PR TITLE
MDCACHE: add lru release entries process

### DIFF
--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_debug.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_debug.h
@@ -33,6 +33,7 @@
 #define MDCACHE_DEBUG_H
 
 #include "mdcache_int.h"
+#include "mdcache_lru.h"
 
 /**
  * @brief Get the sub-FSAL handle from an MDCACHE handle
@@ -54,6 +55,5 @@ struct fsal_obj_handle *mdcdb_get_sub_handle(struct fsal_obj_handle *obj_hdl)
 	return entry->sub_handle;
 }
 
-void lru_cleanup_entries(void);
 
 #endif /* MDCACHE_DEBUG_H */

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_ext.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_ext.h
@@ -69,6 +69,11 @@ struct mdcache_parameter {
 	/** High water mark for cache entries.  Defaults to 100000,
 	    settable by Entries_HWMark. */
 	uint32_t entries_hwmark;
+	/** When the handle cache is over the high water mark, attempt to
+	    release this number of entries in each pass until it's back below
+	    the high water mark. Set it to 0 does not attempt to release
+	    entries. Defaults to 100, settable by Entries_Release_Size. */
+	uint32_t entries_release_size;
 	/** High water mark for chunks.  Defaults to 100000,
 	    settable by Chunks_HWMark. */
 	uint32_t chunks_hwmark;

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_lru.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_lru.c
@@ -1381,6 +1381,34 @@ lru_run(struct fridgethr_context *ctx)
 		}
 	}
 
+	/* We're trying to release the entry cache if the amount
+	 * used is higher than the water level. every time we can
+	 * try best to release the number of entries until entries
+	 * cache below the high water mark. the max number of entries
+	 * released per time is entries_release_size.
+	 */
+	if (lru_state.entries_release_size > 0) {
+		if (lru_state.entries_used > lru_state.entries_hiwat) {
+			size_t released = 0;
+
+			LogFullDebug(COMPONENT_CACHE_INODE_LRU,
+				"Entries used is %" PRIu64
+				" and above water mark, LRU want release %d entries",
+				lru_state.entries_used,
+				lru_state.entries_release_size);
+
+			released = mdcache_lru_release_entries(
+					lru_state.entries_release_size);
+			LogFullDebug(COMPONENT_CACHE_INODE_LRU,
+				"Actually release %zd entries", released);
+		} else {
+			LogFullDebug(COMPONENT_CACHE_INODE_LRU,
+				"Entries used is %" PRIu64
+				" and low water mark: not releasing",
+				lru_state.entries_used);
+		}
+	}
+
 	/* The following calculation will progressively garbage collect
 	 * more frequently as these two factors increase:
 	 * 1. current number of open file descriptors
@@ -1565,30 +1593,40 @@ static void chunk_lru_run(struct fridgethr_context *ctx)
 		 ((uint64_t) new_thread_wait), totalwork);
 }
 
-/**
- * @brief Remove reapable entries until we are below the high-water mark
+/* @brief Release reapable entries until we are below the high-water mark
  *
  * If something refs a lot of entries at the same time, this can put the number
- * of entries above the high water mark.  They will slowly fall, as entries are
- * actually freed, but this may take a very long time.
+ * of entries above the high water mark. Every time we want try best to release
+ * the number of entries, the max number is want_release.
  *
- * This is a big hammer, that will clean up anything it can until either it
- * can't anymore, or we're back below the high water mark.
+ * Normally, want_release equals Entries_Relesase_Size, If it is set to -1
+ * or negative, this going to be a big hammer, that will clean up anything it
+ * can until either it can't anymore, or we're back below the high water mark.
  *
- * @param[in] parm     Parameter description
- * @return Return description
+ * @param[in] want_release Maximum number of entries released. Note that if set
+ *	      negative number, it indicates release all until can't release
+ * @return Return the number of really released
  */
-void lru_cleanup_entries(void)
+size_t mdcache_lru_release_entries(int32_t want_release)
 {
 	mdcache_lru_t *lru;
 	mdcache_entry_t *entry = NULL;
+	size_t released = 0;
+
+	/*release nothing*/
+	if (want_release == 0)
+		return released;
 
 	while ((lru = lru_try_reap_entry())) {
-		if (lru) {
-			entry = container_of(lru, mdcache_entry_t, lru);
-			mdcache_lru_unref(entry);
-		}
+		entry = container_of(lru, mdcache_entry_t, lru);
+		mdcache_lru_unref(entry);
+		++released;
+
+		if (want_release > 0 && released >= want_release)
+			break;
 	}
+
+	return released;
 }
 
 void init_fds_limit(void)
@@ -1720,6 +1758,9 @@ mdcache_lru_pkginit(void)
 	   bit fishy, so come back and revisit this. */
 	lru_state.entries_hiwat = mdcache_param.entries_hwmark;
 	lru_state.entries_used = 0;
+
+	/* set lru release entries size */
+	lru_state.entries_release_size = mdcache_param.entries_release_size;
 
 	/* Set high and low watermark for chunks.  XXX This seems a
 	   bit fishy, so come back and revisit this. */

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_lru.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_lru.h
@@ -74,6 +74,7 @@ enum fd_states {
 struct lru_state {
 	uint64_t entries_hiwat;
 	uint64_t entries_used;
+	uint32_t entries_release_size;
 	uint64_t chunks_hiwat;
 	uint64_t chunks_used;
 	uint32_t fds_system_imposed;
@@ -157,6 +158,8 @@ fsal_status_t _mdcache_lru_ref(mdcache_entry_t *entry, uint32_t flags,
 void mdcache_lru_kill(mdcache_entry_t *entry);
 void mdcache_lru_cleanup_push(mdcache_entry_t *entry);
 void mdcache_lru_cleanup_try_push(mdcache_entry_t *entry);
+
+size_t mdcache_lru_release_entries(int32_t want_release);
 
 #define mdcache_lru_unref(e) _mdcache_lru_unref(e, LRU_FLAG_NONE, \
 						__func__, __LINE__)

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_read_conf.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_read_conf.c
@@ -65,6 +65,8 @@ static struct config_item mdcache_params[] = {
 		       mdcache_parameter, dir.avl_detached_mult),
 	CONF_ITEM_UI32("Entries_HWMark", 1, UINT32_MAX, 100000,
 		       mdcache_parameter, entries_hwmark),
+	CONF_ITEM_UI32("Entries_Release_Size", 0, UINT32_MAX, 100,
+		       mdcache_parameter, entries_release_size),
 	CONF_ITEM_UI32("Chunks_HWMark", 1, UINT32_MAX, 100000,
 		       mdcache_parameter, chunks_hwmark),
 	CONF_ITEM_UI32("LRU_Run_Interval", 1, 24 * 3600, 90,

--- a/src/config_samples/config.txt
+++ b/src/config_samples/config.txt
@@ -568,6 +568,8 @@ MDCACHE / CACHEINODE
 
 	Entries_HWMark(uint32, range 1 to UINT32_MAX, default 100000)
 
+	Entries_Release_Size(uint32, range 0 to UINT32_MAX, default 100)
+
 	LRU_Run_Interval(uint32, range 1 to 24 * 3600, default 90)
 
 	FD_Limit_Percent(uint32, range 0 to 100, default 99)

--- a/src/doc/man/ganesha-cache-config.rst
+++ b/src/doc/man/ganesha-cache-config.rst
@@ -44,6 +44,10 @@ Detached_Mult(uint32, range 1 to UINT32_MAX, default 1)
 Entries_HWMark(uint32, range 1 to UINT32_MAX, default 100000)
     The point at which object cache entries will start being reused.
 
+Entries_Release_Size(uint32, range 0 to UINT32_MAX, default 100)
+    The number of entries attempted to release each time when the handle
+    cache has exceeded the entries high water mark.
+
 Chunks_HWMark(uint32, range 1 to UINT32_MAX, default 100000)
     The point at which dirent cache chunks will start being reused.
 

--- a/src/gtest/fsal_api/test_readdir_correctness.cc
+++ b/src/gtest/fsal_api/test_readdir_correctness.cc
@@ -124,7 +124,7 @@ namespace {
       }
 
       /* Clean up extra entries */
-      lru_cleanup_entries();
+      mdcache_lru_release_entries(-1);
     }
 
     virtual void TearDown() {


### PR DESCRIPTION
If something refs a lot of entries at the same time and above the
high water mark, we have no way to release cache entries below water
level,though it can be released.

By adding this process, every time we can try best to release the number
of entries until entries used below the water level, the max number of
release per time is Entries_Release_Size.

back ported from ganeshaV4.0dev commit
@b91fe031ab1ba17181dfaf50668227b15c9eb3d5

Signed-off-by: Chakra Divi <chakra.divi@hpe.com>