### PR TITLE
Fix op_ctx handling for async FSALs

### DIFF
--- a/src/MainNFSD/nfs_worker_thread.c
+++ b/src/MainNFSD/nfs_worker_thread.c
@@ -1532,6 +1532,13 @@ static enum xprt_stat nfs_rpc_process_request(nfs_request_t *reqdata)
 
 	free_args(reqdata);
 
+	/* Make sure no-one called init_op_context() without calling
+	 * release_op_context() */
+	assert(op_ctx == NULL);
+	/* Make sure we return to ntirpc without op_ctx set, or saved_op_ctx can
+	 * point to freed memory */
+	op_ctx = NULL;
+
 	return SVC_STAT(xprt);
 }
 

--- a/src/Protocols/NFS/nfs4_Compound.c
+++ b/src/Protocols/NFS/nfs4_Compound.c
@@ -1099,6 +1099,7 @@ static enum xprt_stat nfs4_compound_resume(struct svc_req *req)
 		 * already been set up before we started proecessing
 		 * ops on this request at all.
 		 */
+		op_ctx = NULL;
 		return XPRT_SUSPEND;
 	}
 
@@ -1115,6 +1116,7 @@ static enum xprt_stat nfs4_compound_resume(struct svc_req *req)
 			 * already been set up before we started proecessing
 			 * ops on this request at all.
 			 */
+			op_ctx = NULL;
 			return XPRT_SUSPEND;
 		}
 	}


### PR DESCRIPTION
When we suspend a request, we cannot touch the contents of op_ctx,
because the callback may have already run, and may have freed the
request (and therefore the op_ctx).  All we can do is NULL out op_ctx,
so that future calls don't get a save_op_ctx set wrongly.

Change-Id: I139f68032bfe3233e13b96c8e5bf544258681a68
Signed-off-by: Daniel Gryniewicz <dang@redhat.com>

The above commit from nfs-ganesha next branch ported
to V3-Stable

Signed-off-by: Chakra Divi <chakragithub@gmail.com>