### PR TITLE
MDCACHE - Ensure ATTR4_FS_LOCATIONS and ATTR4_SEC_LABEL bits aren't lost

### DIFF
--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c
@@ -1,7 +1,7 @@
 /*
  * vim:noexpandtab:shiftwidth=8:tabstop=8:
  *
- * Copyright 2015-2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015-2021 Red Hat, Inc. and/or its affiliates.
  * Author: Daniel Gryniewicz <dang@redhat.com>
  *
  * This program is free software; you can redistribute it and/or
@@ -859,6 +859,16 @@ fsal_status_t mdcache_refresh_attrs(mdcache_entry_t *entry, bool need_acl,
 	if (entry->attrs.acl != NULL) {
 		/* request_mask & ATTR_ACL must match attrs.acl */
 		entry->attrs.request_mask |= ATTR_ACL;
+	}
+	if (entry->attrs.fs_locations != NULL) {
+		/* request_mask & ATTR_FS_LOCATIONS must match
+		 * attrs.fs_locations */
+		entry->attrs.request_mask |= ATTR4_FS_LOCATIONS;
+	}
+	if (entry->attrs.sec_label.slai_data.slai_data_val != NULL) {
+		/* request_mask & ATTR_ACL must match
+		 * attrs.sec_label.slai_data.slai_data_val */
+		entry->attrs.request_mask |= ~ATTR4_SEC_LABEL;
 	}
 
 	original_generation = atomic_fetch_int32_t(&entry->attr_generation);


### PR DESCRIPTION
The refresh/copy/ref-handoff code depends on the ATTR4_* bits in request_mask always matching the associated pointers.  However, mdcache_refresh_attrs() overwrites request_mask with the given one, losing this relationship.  Fix it up, to make sure the bits are always set when the pointers are non-NULL.  This was already done for ACL, but not for FS_LOCATIONS or SEC_LABEL

Change-Id: I5784a797545f0ab4bf8562594431134484fbe757

The above commit from nfs-ganesha V4-rc1 branch backported to branch to fix fs_locations EIO error when accessing referrals