### PR TITLE
MFS-18862: set mount_path_pseudo to true by default

### DIFF
--- a/src/support/nfs_read_conf.c
+++ b/src/support/nfs_read_conf.c
@@ -307,7 +307,7 @@ static struct config_item core_params[] = {
 		       nfs_core_param, resolve_fs_retries),
 	CONF_ITEM_UI32("resolve_fs_delay", 1, 1000, 100,
 		       nfs_core_param, resolve_fs_delay),
-	CONF_ITEM_BOOL("mount_path_pseudo", false,
+	CONF_ITEM_BOOL("mount_path_pseudo", true,
 		       nfs_core_param, mount_path_pseudo),
 	CONF_ITEM_ENUM_BITS("Enable_UDP", UDP_LISTENER_ALL, UDP_LISTENER_MASK,
 		       udp_listener_type, nfs_core_param, enable_UDP),


### PR DESCRIPTION
Fix Description:
ganesha v3.3 did not used this option to show exports when pseduo path is set, it used to show pseduo path else full path. But mount_path_pseudo option which is by default false must be true to show pseduo exports so changing the default value to true, such that there is no explicit behavior change for end user
After this change unless you specify pseudo path, nothing gets displayed as part of list-exports

skipBuild unitTested review @shyam