### PR TITLE
MFS-23075: add support_server_aces conf option

### DIFF
--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_ext.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_ext.h
@@ -129,6 +129,9 @@ struct mdcache_parameter {
 	/** High water mark for dirent mapping entries.  Defaults to 10000,
 	    settable by Dirmap_HWMark. */
 	uint32_t dirmap_hwmark;
+	/** When true, delegate access checks to the sub-FSAL.
+	    Defaults to false, settable with support_server_aces. */
+	bool support_server_aces;
 };
 
 extern struct mdcache_parameter mdcache_param;

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c
@@ -602,6 +602,20 @@ static fsal_status_t mdcache_test_access(struct fsal_obj_handle *obj_hdl,
 	if (owner_skip && entry->attrs.owner == op_ctx->creds.caller_uid)
 		return fsalstat(ERR_FSAL_NO_ERROR, 0);
 
+	/* When support_server_aces is enabled, ask the sub-FSAL if it needs
+	 * to handle access resolution (e.g., mode==0 means ACL-only on backend).
+	 */
+	if (mdcache_param.support_server_aces &&
+	    entry->sub_handle->obj_ops->enforce_perm_on_server(
+						entry->sub_handle)) {
+		LogDebug(COMPONENT_MDCACHE,
+			 "Delegating access check to sub-FSAL for entry %p",
+			 entry);
+		return entry->sub_handle->obj_ops->test_access(
+				entry->sub_handle, access_type,
+				allowed, denied, owner_skip);
+	}
+
 	return fsal_test_access(obj_hdl, access_type, allowed, denied,
 				owner_skip);
 }

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_read_conf.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_read_conf.c
@@ -94,6 +94,8 @@ static struct config_item mdcache_params[] = {
 		       mdcache_parameter, futility_count),
 	CONF_ITEM_UI32("Dirmap_HWMark", 1, UINT32_MAX, 10000,
 		       mdcache_parameter, dirmap_hwmark),
+	CONF_ITEM_BOOL("support_server_aces", false,
+		       mdcache_parameter, support_server_aces),
 	CONFIG_EOL
 };
 

--- a/src/FSAL/default_methods.c
+++ b/src/FSAL/default_methods.c
@@ -1484,6 +1484,14 @@ static bool is_referral(struct fsal_obj_handle *obj_hdl,
 	return false;
 }
 
+/**
+ * @brief Default enforce_perm_on_server - always returns false
+ */
+static bool enforce_perm_on_server_default(struct fsal_obj_handle *obj_hdl)
+{
+	return false;
+}
+
 /* Default fsal handle object method vector.
  * copied to allocated vector at register time
  */
@@ -1501,6 +1509,7 @@ struct fsal_obj_ops def_handle_ops = {
 	.mknode = makenode,
 	.symlink = makesymlink,
 	.readlink = readsymlink,
+	.enforce_perm_on_server = enforce_perm_on_server_default,
 	.test_access = fsal_test_access,	/* default is use common test */
 	.getattrs = getattrs,
 	.link = linkfile,

--- a/src/config_samples/ganesha.conf.example
+++ b/src/config_samples/ganesha.conf.example
@@ -31,6 +31,10 @@
 #MDCACHE {
 	## The point at which object cache entries will start being reused.
 	#Entries_HWMark = 100000;
+
+	## When true, delegate all access checks to the sub-FSAL.
+	## Enable for MapRFS where mode=0 means ACL-only enforcement.
+	#support_server_aces = false;
 #}
 
 ## Configure an export for some file tree

--- a/src/include/fsal_api.h
+++ b/src/include/fsal_api.h
@@ -1874,6 +1874,20 @@ struct fsal_obj_ops {
 				   bool refresh);
 
 /**
+ * @brief Check if access resolution must be handled by the FSAL
+ *
+ * Returns true if the FSAL requires access checks to be delegated
+ * to it (e.g., when mode bits are 0 and ACLs are enforced on the
+ * backend). When true, MDCACHE will call the FSAL's test_access
+ * instead of evaluating permissions locally.
+ *
+ * @param[in] obj_hdl     Handle to check
+ *
+ * @return true if FSAL must handle access checks, false otherwise.
+ */
+	 bool (*enforce_perm_on_server)(struct fsal_obj_handle *obj_hdl);
+
+/**
  * @brief Check access for a given user against a given object
  *
  * This function checks whether a given user is allowed to perform the


### PR DESCRIPTION
Added needs_server_access fsal api and conf option
when this conf is set to true, and needs_server_access_fsal
retuns true , we bypass mdcache access check and use fsal test
access always so that access check always happens on server.

skipBuild unitTested review @shyam